### PR TITLE
(SMTP) Add support for alias for sender email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work.sum
 .idea/
 
 *.http
+
+ignore/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Small email service written in GO
       "configuration": {
         "host": "smtp.gmail.com",
         "port": 587,
+        "alias": "John Doe",
         "from": "sender@gmail.com",
         "password": "p4$$w0rd"
       }
@@ -63,4 +64,13 @@ To deploy this project run
   go build
   ./emailer
 ```
+
+## Changelog
+
+- 0.1.1
+  - Allow alias for sender
+- 0.1.0
+  - Initial Release
+  - SMTP Support
+  - Attachments Support
 

--- a/internal/send/sendEmail.go
+++ b/internal/send/sendEmail.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"mime/multipart"
 	"net/http"
+	"net/mail"
 	"net/smtp"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ type Attachment struct {
 type SMTPConfiguration struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
+	Alias    string `json:"alias,omitempty"`
 	From     string `json:"from"`
 	Password string `json:"password"`
 }
@@ -78,6 +80,11 @@ func (request *EmailRequest) sendEmail() error {
 func (request *EmailRequest) toBytes() []byte {
 	buffer := bytes.NewBuffer(nil)
 	withAttachments := len(request.Attachments) > 0
+	from := mail.Address{
+		Name:    request.Configuration.Alias,
+		Address: request.Configuration.From,
+	}
+	buffer.WriteString(fmt.Sprintf("From: %s\n", from.String()))
 	buffer.WriteString(fmt.Sprintf("Subject: %s\n", request.Subject))
 	buffer.WriteString(fmt.Sprintf("To: %s\n", strings.Join(request.To, ",")))
 	if len(request.Cc) > 0 {


### PR DESCRIPTION
Added nullable `alias` parameter in SMTP configuration for sender aliases